### PR TITLE
ENH: Simplify setting extra source mode for WinProbe

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1405,7 +1405,7 @@ int vtkPlusWinProbeVideoSource::GetMWidth()
   if(Connected)
   {
     m_ExtraFrameSize[0] = ::GetMWidth();
-    mwidthSeconds = this->MSecondsFromWidth(m_ExtraFrameSize[1]);
+    mwidthSeconds = this->MSecondsFromWidth(m_ExtraFrameSize[0]);
   }
   return mwidthSeconds;
 }
@@ -1426,7 +1426,7 @@ int32_t vtkPlusWinProbeVideoSource::GetMWidthLines()
   {
     m_ExtraFrameSize[0] = ::GetMWidth();
   }
-  return m_ExtraFrameSize[1];
+  return m_ExtraFrameSize[0];
 }
 
 void vtkPlusWinProbeVideoSource::SetMAcousticLineCount(int32_t value)

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1198,41 +1198,91 @@ int32_t vtkPlusWinProbeVideoSource::GetSpatialCompoundCount()
 }
 
 //----------------------------------------------------------------------------
-
-void vtkPlusWinProbeVideoSource::SetBRFEnabled(bool value)
+PlusStatus vtkPlusWinProbeVideoSource::SetExtraSourceMode(Mode mode)
 {
-  if(Connected)
+  if ((GetBRFEnabled() && mode == Mode::BRF) || (GetMModeEnabled() && mode == Mode::M) || (GetARFIEnabled() && mode == Mode::ARFI))
   {
-    if(m_Mode == Mode::M)
-    {
-      SetMIsEnabled(false);
-    }
-    if(m_Mode == Mode::ARFI)
-    {
-      SetARFIEnabled(false);
-    }
-    if(value)
-    {
-      SetHandleBRFInternally(false);
-      SetBFRFImageCaptureMode(2);
-    }
-    else
-    {
-      SetHandleBRFInternally(true);
-      SetBFRFImageCaptureMode(0);
-    }
+    return PLUS_SUCCESS;
   }
+  SetMIsEnabled(mode == Mode::M);
+  SetARFIIsEnabled(mode == Mode::ARFI);
 
-  if(value)
+  if (mode == Mode::BRF)
   {
-    m_Mode = Mode::BRF;
+    SetHandleBRFInternally(false);
+    SetBFRFImageCaptureMode(2);
   }
   else
   {
-    m_Mode = Mode::B;
+    SetHandleBRFInternally(true);
+    SetBFRFImageCaptureMode(0);
   }
+
+  if(mode == Mode::M)
+  {
+    SetMIsRevolving(m_MRevolvingEnabled);
+    SetMPRF(m_MPRF);
+    SetMAcousticLineIndex(m_MLineIndex);
+    ::SetMWidth(2000);
+    // ::SetMWidth(m_ExtraFrameSize[0]);
+    ::SetMAcousticLineCount(m_MAcousticLineCount);
+  }
+  else if (mode == Mode::ARFI)
+  {
+    m_Mode = Mode::ARFI;
+    unsigned bSize = m_SSDecimation * m_PrimaryFrameSize[1] * m_PrimaryFrameSize[0];
+    unsigned arfiDataSize = 1024 * 16 * 64 * 30;
+    unsigned timeblockSize = (4 / 2) * 64 * 30;
+    m_ExtraFrameSize = { bSize + arfiDataSize + timeblockSize, 1, 1 };
+    this->AdjustBufferSizes();
+    std::vector<int32_t> zeroData(m_ExtraFrameSize[0] * m_ExtraFrameSize[1] * m_ExtraFrameSize[2], 0);
+    // add a fake zero-filled frame immediately, because the first frame seems to get lost somehow
+    for(unsigned i = 0; i < m_ExtraSources.size(); i++)
+    {
+      double timestamp = vtkIGSIOAccurateTimer::GetSystemTime();
+      if(m_ExtraSources[i]->AddItem(&zeroData[0],
+                                    US_IMG_ORIENT_FM,
+                                    m_ExtraFrameSize, VTK_INT,
+                                    1, US_IMG_RF_REAL, 0,
+                                    this->FrameNumber,
+                                    timestamp,
+                                    timestamp,
+                                    &m_CustomFields) != PLUS_SUCCESS)
+      {
+        LOG_WARNING("Error adding fake zeros item to ARFI video source " << m_ExtraSources[i]->GetSourceId());
+      }
+      else
+      {
+        LOG_WARNING("Success adding fake zeros item to ARFI video source ");
+      }
+    }
+    LOG_DEBUG("GetARFIIsRFSampleDataCaptureEnabled: " << GetARFIIsRFSampleDataCaptureEnabled());
+  }
+  SetPendingRecreateTables(true);
+  LOG_INFO("Mode changed to: " << ModeToString(mode));
+  m_Mode = mode;
+  return PLUS_SUCCESS;
 }
 
+//----------------------------------------------------------------------------
+void vtkPlusWinProbeVideoSource::SetBRFEnabled(bool value)
+{
+  SetExtraSourceMode(Mode::BRF);
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
+{
+  SetExtraSourceMode(Mode::M);
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusWinProbeVideoSource::SetARFIEnabled(bool value)
+{
+  SetExtraSourceMode(Mode::ARFI);
+}
+
+//----------------------------------------------------------------------------
 bool vtkPlusWinProbeVideoSource::GetBRFEnabled()
 {
   bool brfEnabled = (m_Mode == Mode::BRF);
@@ -1264,42 +1314,6 @@ bool vtkPlusWinProbeVideoSource::GetBHarmonicEnabled()
     m_BHarmonicEnabled = GetBIsHarmonic();
   }
   return m_BHarmonicEnabled;
-}
-
-//----------------------------------------------------------------------------
-
-void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
-{
-  if(Connected)
-  {
-    if(m_Mode == Mode::BRF)
-    {
-      SetBRFEnabled(false);
-    }
-    if(m_Mode == Mode::ARFI)
-    {
-      SetARFIEnabled(false);
-    }
-    SetMIsEnabled(value);
-    if(value)
-    {
-      SetMIsRevolving(m_MRevolvingEnabled);
-      SetMPRF(m_MPRF);
-      SetMAcousticLineIndex(m_MLineIndex);
-      ::SetMWidth(m_ExtraFrameSize[0]);
-      ::SetMAcousticLineCount(m_MAcousticLineCount);
-    }
-    SetPendingRecreateTables(true);
-    LOG_INFO("M-Mode enabled");
-  }
-  if(value)
-  {
-    m_Mode = Mode::M;
-  }
-  else
-  {
-    m_Mode = Mode::B;
-  }
 }
 
 bool vtkPlusWinProbeVideoSource::GetMModeEnabled()
@@ -1498,59 +1512,6 @@ std::vector<double> vtkPlusWinProbeVideoSource::GetExtraSourceSpacing()
     }
   }
   return spacing;
-}
-
-void vtkPlusWinProbeVideoSource::SetARFIEnabled(bool value)
-{
-  if(Connected)
-  {
-    if(m_Mode == Mode::M)
-    {
-      SetMIsEnabled(false);
-    }
-    if(m_Mode == Mode::BRF)
-    {
-      SetBRFEnabled(false);
-    }
-    SetARFIIsEnabled(value);
-    SetPendingRecreateTables(true);
-    if(value)
-    {
-      m_Mode = Mode::ARFI;
-      unsigned bSize = m_SSDecimation * m_PrimaryFrameSize[1] * m_PrimaryFrameSize[0];
-      unsigned arfiDataSize = 1024 * 16 * 64 * 30;
-      unsigned timeblockSize = (4 / 2) * 64 * 30;
-      m_ExtraFrameSize = { bSize + arfiDataSize + timeblockSize, 1, 1 };
-      this->AdjustBufferSizes();
-      std::vector<int32_t> zeroData(m_ExtraFrameSize[0] * m_ExtraFrameSize[1] * m_ExtraFrameSize[2], 0);
-      // add a fake zero-filled frame immediately, because the first frame seems to get lost somehow
-      for(unsigned i = 0; i < m_ExtraSources.size(); i++)
-      {
-        double timestamp = vtkIGSIOAccurateTimer::GetSystemTime();
-        if(m_ExtraSources[i]->AddItem(&zeroData[0],
-                                      US_IMG_ORIENT_FM,
-                                      m_ExtraFrameSize, VTK_INT,
-                                      1, US_IMG_RF_REAL, 0,
-                                      this->FrameNumber,
-                                      timestamp,
-                                      timestamp,
-                                      &m_CustomFields) != PLUS_SUCCESS)
-        {
-          LOG_WARNING("Error adding fake zeros item to ARFI video source " << m_ExtraSources[i]->GetSourceId());
-        }
-        else
-        {
-          LOG_WARNING("Success adding fake zeros item to ARFI video source ");
-        }
-      }
-
-      LOG_DEBUG("GetARFIIsRFSampleDataCaptureEnabled: " << GetARFIIsRFSampleDataCaptureEnabled());
-    }
-    else
-    {
-      m_Mode = Mode::B;
-    }
-  }
 }
 
 bool vtkPlusWinProbeVideoSource::GetARFIEnabled()

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -95,7 +95,7 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
       int mwidthSeconds = std::stoi(mwidthSeconds_string);
       if(mwidthSeconds > 0)
       {
-        m_ExtraFrameSize[0] = this->MWidthFromSeconds(mwidthSeconds);
+        m_MWidth = this->MWidthFromSeconds(mwidthSeconds);
       }
     }
   }
@@ -122,8 +122,8 @@ PlusStatus vtkPlusWinProbeVideoSource::WriteConfiguration(vtkXMLDataElement* roo
   deviceConfig->SetIntAttribute("SpatialCompoundCount", this->GetSpatialCompoundCount());
   deviceConfig->SetIntAttribute("MPRFrequency", this->GetMPRFrequency());
   deviceConfig->SetIntAttribute("MLineIndex", this->GetMLineIndex());
-  deviceConfig->SetIntAttribute("MWidth", this->MSecondsFromWidth(this->m_ExtraFrameSize[0]));
-  deviceConfig->SetIntAttribute("MWidthLines", this->m_ExtraFrameSize[0]);
+  deviceConfig->SetIntAttribute("MWidth", this->MSecondsFromWidth(this->m_MWidth));
+  deviceConfig->SetIntAttribute("MWidthLines", this->m_MWidth);
   deviceConfig->SetIntAttribute("MAcousticLineCount", this->GetMAcousticLineCount());
   deviceConfig->SetIntAttribute("MDepth", this->GetMDepth());
   deviceConfig->SetUnsignedLongAttribute("Voltage", this->GetVoltage());
@@ -607,13 +607,14 @@ void vtkPlusWinProbeVideoSource::AdjustBufferSizes()
     }
     else if(m_Mode == Mode::M)
     {
+      frameSize[0] = m_MWidth;
       m_ExtraSources[i]->SetPixelType(VTK_UNSIGNED_CHAR);
       m_ExtraSources[i]->SetImageType(US_IMG_BRIGHTNESS);
       m_ExtraSources[i]->SetOutputImageOrientation(US_IMG_ORIENT_MF);
       m_ExtraSources[i]->SetInputImageOrientation(US_IMG_ORIENT_MF);
-      if(m_ExtraBuffer.size() != m_ExtraFrameSize[0] * m_ExtraFrameSize[1])
+      if(m_ExtraBuffer.size() != m_MWidth * m_ExtraFrameSize[1])
       {
-        m_ExtraBuffer.resize(m_ExtraFrameSize[0] * m_ExtraFrameSize[1]);
+        m_ExtraBuffer.resize(m_MWidth * m_ExtraFrameSize[1]);
         std::fill(m_ExtraBuffer.begin(), m_ExtraBuffer.end(), 0);
       }
     }
@@ -842,7 +843,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     SetMIsRevolving(m_MRevolvingEnabled);
     SetMPRF(m_MPRF);
     SetMAcousticLineIndex(m_MLineIndex);
-    ::SetMWidth(m_ExtraFrameSize[0]);
+    ::SetMWidth(m_MWidth);
     ::SetMAcousticLineCount(m_MAcousticLineCount);
   }
 
@@ -1223,8 +1224,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetExtraSourceMode(Mode mode)
     SetMIsRevolving(m_MRevolvingEnabled);
     SetMPRF(m_MPRF);
     SetMAcousticLineIndex(m_MLineIndex);
-    ::SetMWidth(2000);
-    // ::SetMWidth(m_ExtraFrameSize[0]);
+    ::SetMWidth(m_MWidth);
     ::SetMAcousticLineCount(m_MAcousticLineCount);
   }
   else if (mode == Mode::ARFI)
@@ -1395,7 +1395,7 @@ void vtkPlusWinProbeVideoSource::SetMWidth(int value)
     int32_t mwidth = this->MWidthFromSeconds(value);
     ::SetMWidth(mwidth);
     SetPendingRecreateTables(true);
-    m_ExtraFrameSize[0] = mwidth;
+    m_MWidth = mwidth;
   }
 }
 
@@ -1404,8 +1404,8 @@ int vtkPlusWinProbeVideoSource::GetMWidth()
   int mwidthSeconds = 0;
   if(Connected)
   {
-    m_ExtraFrameSize[0] = ::GetMWidth();
-    mwidthSeconds = this->MSecondsFromWidth(m_ExtraFrameSize[0]);
+    m_MWidth = ::GetMWidth();
+    mwidthSeconds = this->MSecondsFromWidth(m_MWidth);
   }
   return mwidthSeconds;
 }
@@ -1417,16 +1417,16 @@ void vtkPlusWinProbeVideoSource::SetMWidthLines(int32_t value)
     ::SetMWidth(value);
     SetPendingRecreateTables(true);
   }
-  m_ExtraFrameSize[0] = value;
+  m_MWidth = value;
 }
 
 int32_t vtkPlusWinProbeVideoSource::GetMWidthLines()
 {
   if(Connected)
   {
-    m_ExtraFrameSize[0] = ::GetMWidth();
+    m_MWidth = ::GetMWidth();
   }
-  return m_ExtraFrameSize[0];
+  return m_MWidth;
 }
 
 void vtkPlusWinProbeVideoSource::SetMAcousticLineCount(int32_t value)

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -195,6 +195,8 @@ public:
     CFD // Color-Flow Doppler
   };
 
+  PlusStatus SetExtraSourceMode(Mode mode);
+
   /*! Sets the ultrasound imaging mode. */
   void SetMode(Mode mode)
   {

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -276,6 +276,7 @@ protected:
   int32_t m_BMultiTxCount = 1;
   int32_t m_MPRF = 100;
   int32_t m_MLineIndex = 60;
+  int32_t m_MWidth = 256;
   int32_t m_MAcousticLineCount = 0;
   int32_t m_MDepth = 0;
   uint8_t m_SSDecimation = 2;


### PR DESCRIPTION
This is some of my work for fixing the switching between modes by simplifying the switch logic. 

Currently still having issues where `::SetMWidth(m_ExtraFrameSize[0]);` is getting set to the previous mode width such as RF (1536) instead of the 2000 value. Maybe `GetMWidth()` would work? Though it is also using m_ExtraFrameSize[0]