### PR TITLE
ENH: expose more even more WinProbe ARFI parameters

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -41,6 +41,10 @@ void vtkPlusWinProbeVideoSource::PrintSelf(ostream& os, vtkIndent indent)
   {
     os << indent << "FocalPointDepth" << i << ": " << m_FocalPointDepth[i] << std::endl;
   }
+  for(int i = 0; i < 6; i++)
+  {
+    os << indent << "ARFIFocalPointDepth" << i << ": " << m_ARFIFocalPointDepth[i] << std::endl;
+  }
 
   os << indent << "CustomFields: " << std::endl;
   vtkIndent indent2 = indent.GetNextIndent();
@@ -800,6 +804,17 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     m_FocalPointDepth[i] = ::GetFocalPointDepth(i);
   }
 
+  SetARFIMultiFocalZoneCount(m_ARFIMultiTxCount);
+  for(int i = 0; i < 6; i++)
+  {
+    SetARFIFocalPointDepth(i, m_ARFIFocalPointDepth[i]);
+  }
+
+  SetARFITxTxCycleCount(m_ARFITxTxCycleCount);
+  SetARFITxTxCycleWidth(m_ARFITxTxCycleWidth);
+  SetARFITxCycleCount(m_ARFITxCycleCount);
+  SetARFITxCycleWidth(m_ARFITxCycleWidth);
+
   this->Connected = true; // the setters and getters check this
   this->SetTransmitFrequencyMHz(m_Frequency);
   this->SetVoltage(m_Voltage);
@@ -1107,6 +1122,70 @@ PlusStatus vtkPlusWinProbeVideoSource::SetFocalPointDepth(int index, float depth
 }
 
 //----------------------------------------------------------------------------
+float vtkPlusWinProbeVideoSource::GetARFIFocalPointDepth(int index)
+{
+  assert(index >= 0 && index < 6);
+  if(Connected)
+  {
+    switch (index) {
+    case 0:
+      m_ARFIFocalPointDepth[index] = GetARFIFocal0();
+      break;
+    case 1:
+      m_ARFIFocalPointDepth[index] = GetARFIFocal1();
+      break;
+    case 2:
+      m_ARFIFocalPointDepth[index] = GetARFIFocal2();
+      break;
+    case 3:
+      m_ARFIFocalPointDepth[index] = GetARFIFocal3();
+      break;
+    case 4:
+      m_ARFIFocalPointDepth[index] = GetARFIFocal4();
+      break;
+    case 5:
+      m_ARFIFocalPointDepth[index] = GetARFIFocal5();
+      break;
+    }
+  }
+  return m_ARFIFocalPointDepth[index];
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetARFIFocalPointDepth(int index, float depth)
+{
+  assert(index >= 0 && index < 6);
+  m_ARFIFocalPointDepth[index] = depth;
+  if(Connected)
+  {
+    switch (index) {
+    case 0:
+      SetARFIFocal0(depth);
+      break;
+    case 1:
+      SetARFIFocal1(depth);
+      break;
+    case 2:
+      SetARFIFocal2(depth);
+      break;
+    case 3:
+      SetARFIFocal3(depth);
+      break;
+    case 4:
+      SetARFIFocal4(depth);
+      break;
+    case 5:
+      SetARFIFocal5(depth);
+      break;
+    }
+    SetPendingRecreateTables(true);
+    //what we requested might be only approximately satisfied
+    m_ARFIFocalPointDepth[index] = GetARFIFocalPointDepth(index);
+  }
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
 int32_t vtkPlusWinProbeVideoSource::GetBMultiFocalZoneCount()
 {
   if(Connected)
@@ -1119,7 +1198,7 @@ int32_t vtkPlusWinProbeVideoSource::GetBMultiFocalZoneCount()
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusWinProbeVideoSource::SetBMultiFocalZoneCount(int32_t count)
 {
-  assert(count >= 1 && count < 4);
+  assert(index > 0 && index =< 4);
   m_BMultiTxCount = count;
   if(Connected)
   {
@@ -1127,6 +1206,120 @@ PlusStatus vtkPlusWinProbeVideoSource::SetBMultiFocalZoneCount(int32_t count)
     SetPendingRecreateTables(true);
   }
   return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int32_t vtkPlusWinProbeVideoSource::GetARFIMultiFocalZoneCount()
+{
+  if(Connected)
+  {
+    m_ARFIMultiTxCount = GetARFIMultiTxCount();
+  }
+  return m_ARFIMultiTxCount;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetARFIMultiFocalZoneCount(int32_t count)
+{
+  assert(index > 0 && index =< 6);
+  m_ARFIMultiTxCount = count;
+  if(Connected)
+  {
+    SetARFIMultiTxCount(count);
+    SetPendingRecreateTables(true);
+  }
+  return PLUS_SUCCESS;
+}
+
+bool vtkPlusWinProbeVideoSource::GetARFIIsX8BFEnabled()
+{
+  if(Connected)
+  {
+    quadBFCount = ::GetARFIIsX8BFEnabled() ? 2 : 1;
+  }
+  return quadBFCount == 2;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetARFITxTxCycleCount(uint16_t propertyValue)
+{
+  assert(propertyValue > 0 && propertyValue =< 16);
+  m_ARFITxTxCycleCount = propertyValue;
+  if(Connected)
+  {
+    ::SetARFITxTxCycleCount(propertyValue);
+  }
+  return PLUS_SUCCESS;
+}
+
+uint16_t vtkPlusWinProbeVideoSource::GetARFITxTxCycleCount()
+{
+  if(Connected)
+  {
+    m_ARFITxTxCycleCount = ::GetARFITxTxCycleCount();
+  }
+  return m_ARFITxCycleCount;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetARFITxTxCycleWidth(uint8_t propertyValue)
+{
+  assert(propertyValue > 0 && propertyValue =< 255);
+  m_ARFITxTxCycleWidth = propertyValue;
+  if(Connected)
+  {
+    ::SetARFITxTxCycleWidth(propertyValue);
+  }
+  return PLUS_SUCCESS;
+}
+
+uint8_t vtkPlusWinProbeVideoSource::GetARFITxTxCycleWidth()
+{
+  if(Connected)
+  {
+    m_ARFITxTxCycleWidth = ::GetARFITxTxCycleWidth();
+  }
+  return m_ARFITxTxCycleWidth;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleCount(uint16_t propertyValue)
+{
+  m_ARFITxCycleCount = propertyValue;
+  if(Connected)
+  {
+    ::SetARFITxTxCycleWidth(propertyValue);
+  }
+  return PLUS_SUCCESS;
+}
+
+uint16_t vtkPlusWinProbeVideoSource::GetARFITxCycleCount()
+{
+  if(Connected)
+  {
+    m_ARFITxCycleCount = ::GetARFITxCycleCount();
+  }
+  return m_ARFITxCycleCount;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleWidth(uint8_t propertyValue)
+{
+  m_ARFITxCycleWidth = propertyValue;
+  if(Connected)
+  {
+    ::SetARFITxCycleWidth(propertyValue);
+  }
+  return PLUS_SUCCESS;
+}
+
+uint8_t vtkPlusWinProbeVideoSource::GetARFITxCycleWidth()
+{
+  if(Connected)
+  {
+    m_ARFITxCycleWidth = ::GetARFITxCycleWidth();
+  }
+  return m_ARFITxCycleCount;
 }
 
 //----------------------------------------------------------------------------

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -81,17 +81,56 @@ public:
   /* Set the TGC First Gain Value near transducer face */
   PlusStatus SetFirstGainValue(double value);
 
-  /* Get the focal depth, index 0 to 4 */
+  /* Get the B-Mode focal depth at a specific index, index 0 to 3 */
   float GetFocalPointDepth(int index);
 
-  /* Set the focal depth, index 0 to 4 */
+  /* Set the B-Mode focal depth at a specific index, index 0 to 3 */
   PlusStatus SetFocalPointDepth(int index, float depth);
 
-  /* Get the number of active focal zones, count 1 to 4 */
+  /* Get the ARFI focal depth at a specific index, index 0 to 5 */
+  float GetARFIFocalPointDepth(int index);
+
+  /* Set the ARFI focal depth at a specific index, index 0 to 5 */
+  PlusStatus SetARFIFocalPointDepth(int index, float depth);
+
+  /* Get the number of active focal zones for B-Mode, count 1 to 4 */
   int32_t GetBMultiFocalZoneCount();
 
-  /* Set the number of active focal zones, count 1 to 4 */
+  /* Set the number of active focal zones for B-Mode, count 1 to 4 */
   PlusStatus SetBMultiFocalZoneCount(int32_t count);
+
+  /* Get the number of active focal zones for ARFI, count 1 to 6 */
+  int32_t GetARFIMultiFocalZoneCount();
+
+  /* Set the number of active focal zones for ARFI, count 1 to 6 */
+  PlusStatus SetARFIMultiFocalZoneCount(int32_t count);
+
+  /* Get if the connected engine has an x8 beamformer. */
+  bool GetARFIIsX8BFEnabled();
+
+  /* Set the number of states in the transmit pulse. 1-16 */
+  PlusStatus vtkPlusWinProbeVideoSource::SetARFITxTxCycleCount(uint16_t propertyValue);
+
+  /* Get the number of states in the transmit pulse. 1-16 */
+  uint16_t vtkPlusWinProbeVideoSource::GetARFITxTxCycleCount();
+
+  /* Set the width of the tx cycle. Determines the transmit frequency for non apodized transmits. 1-255 */
+  PlusStatus vtkPlusWinProbeVideoSource::SetARFITxTxCycleWidth(uint8_t propertyValue);
+
+  /* Get the width of the tx cycle. Determines the transmit frequency for non apodized transmits. 1-255 */
+  uint8_t vtkPlusWinProbeVideoSource::GetARFITxTxCycleWidth();
+
+  /* Set the number of cycles in the ARFI push pulse. */
+  PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleCount(uint16_t propertyValue);
+
+  /* Get the number of cycles in the ARFI push pulse. */
+  uint16_t vtkPlusWinProbeVideoSource::GetARFITxCycleCount();
+
+  /* Set the frequency of the push pulse. */
+  PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleWidth(uint8_t propertyValue);
+
+  /* Get the frequency of the push pulse. */
+  uint8_t vtkPlusWinProbeVideoSource::GetARFITxCycleWidth();
 
   /* Whether or not to use device's built-in frame reconstruction */
   void SetUseDeviceFrameReconstruction(bool value) { m_UseDeviceFrameReconstruction = value; }
@@ -269,6 +308,7 @@ protected:
   igsioFieldMapType m_CustomFields;
   double m_TimeGainCompensation[8];
   float m_FocalPointDepth[4];
+  float m_ARFIFocalPointDepth[6];
   uint16_t m_MinValue = 16; //noise floor
   uint16_t m_MaxValue = 16384; //maximum typical value
   uint16_t m_Knee = 4096; // threshold value for switching from log to linear
@@ -278,6 +318,11 @@ protected:
   int32_t m_SpatialCompoundCount = 0;
   bool m_MRevolvingEnabled = false;
   int32_t m_BMultiTxCount = 1;
+  int32_t m_ARFIMultiTxCount = 1;
+  uint16_t m_ARFITxTxCycleCount = 2;
+  uint8_t m_ARFITxTxCycleWidth = 1;
+  uint16_t m_ARFITxCycleCount = 1;
+  uint8_t m_ARFITxCycleWidth = 4096;
   int32_t m_MPRF = 100;
   int32_t m_MLineIndex = 60;
   int32_t m_MWidth = 256;


### PR DESCRIPTION
Did this:
> In your `ENH: Expose various WinProbe ARFI parameters` commit, please also expose
> 
> * [ ]  SetARFIFocal0
> * [ ]  GetARFIFocal0
> * [ ]  SetARFIFocal1
> * [ ]  GetARFIFocal1
> * [ ]  SetARFIFocal2
> * [ ]  GetARFIFocal2
> * [ ]  SetARFIFocal3
> * [ ]  SetARFITxCycleCount
> * [ ]  GetARFITxCycleCount
> * [ ]  SetARFITxCycleWidth
> * [ ]  GetARFITxCycleWidth
> * [ ]  SetARFITxTxCycleWidth
> * [ ]  GetARFITxTxCycleWidth

GetFocalPointDepth / SetFocalPointDepth are exposed `UltraVisionManagedDll`, and seem to be convenience methods for accessing any B-Mode focal depth with an index instead of with separate methods. There isn't something like this in there for ARFI, so I implemented similar logic here instead so that the way we access focal depth for different imaging modes isn't drastically different.

It's unclear if GetFocalPointDepth / SetFocalPointDepth were intended to eventually cover multiple imaging modes since they're not in `BModeWrapper`, but that isn't the case now.

Also exposed
---
- `SetARFIFocal4` / `SetARFIFocal5` - added by Alix after this comment was written
- `GetARFIIsX8BFEnabled` - per request
- `SetARFITxTxCycleCount` / `GetARFITxTxCycleCount` - These were basically "why nots" because they were documented in the UV API and similar to other settings we exposed. 