### PR TITLE
ENH: Set Andor cool temperature at startup

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -1355,6 +1355,12 @@ int vtkPlusAndorVideoSource::GetCoolerMode()
 // ----------------------------------------------------------------------------
 PlusStatus vtkPlusAndorVideoSource::SetCoolTemperature(int coolTemp)
 {
+  unsigned result = checkStatus(SetTemperature(this->CoolTemperature), "SetTemperature");
+  if(result != DRV_SUCCESS)
+  {
+    LOG_ERROR("SetCoolTemperature command failed.");
+    return PLUS_FAIL;
+  }
   this->CoolTemperature = coolTemp;
 
   return PLUS_SUCCESS;


### PR DESCRIPTION
Call to Andor SDK to set temperature on startup. This is helpful when the Cooler is already on in the idle state and PlusServer is started with a new "CoolTemperature" specified in the config xml.